### PR TITLE
Implement note archiving and archive management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,10 @@ function App() {
     activeNote, 
     activeNoteId, 
     setActiveNoteId, 
-    createNote, 
-    updateNote, 
-    deleteNote 
+    createNote,
+    updateNote,
+    archiveNote,
+    deleteNotes
   } = useNotes();
 
   useEffect(() => {
@@ -37,12 +38,13 @@ function App() {
     <div className="h-screen flex flex-col">
       <div className="flex-1 flex overflow-hidden">
         <div className="w-64 h-full">
-          <NoteList 
+          <NoteList
             notes={notes}
             activeNoteId={activeNoteId}
             onNoteSelect={setActiveNoteId}
             onCreateNote={createNote}
-            onDeleteNote={deleteNote}
+            onArchiveNote={archiveNote}
+            onDeleteArchived={deleteNotes}
           />
         </div>
         

--- a/src/components/archive-dialog.tsx
+++ b/src/components/archive-dialog.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { Note } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogTrigger
+} from '@/components/ui/alert-dialog';
+
+interface ArchiveDialogProps {
+  notes: Note[];
+  onDelete: (ids: string[]) => void;
+}
+
+export function ArchiveDialog({ notes, onDelete }: ArchiveDialogProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const toggleSelect = (id: string) => {
+    setSelected((curr) =>
+      curr.includes(id) ? curr.filter((s) => s !== id) : [...curr, id]
+    );
+  };
+
+  const handleDelete = () => {
+    onDelete(selected);
+    setSelected([]);
+    setConfirmOpen(false);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm">Archive</Button>
+      </DialogTrigger>
+      <DialogContent className="flex flex-col h-96">
+        <DialogHeader>
+          <DialogTitle>Archived Notes</DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="flex-1">
+          <ul className="space-y-2 px-2 py-2">
+            {notes.map((note) => (
+              <li key={note.id} className="flex items-center gap-2">
+                <Checkbox
+                  checked={selected.includes(note.id)}
+                  onCheckedChange={() => toggleSelect(note.id)}
+                />
+                <span className="truncate flex-1 text-sm">{note.title}</span>
+              </li>
+            ))}
+          </ul>
+        </ScrollArea>
+        <div className="pt-2">
+          <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+            <AlertDialogTrigger asChild>
+              <Button disabled={selected.length === 0} className="w-full">
+                Delete Selected
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {`Are you sure you want to delete ${selected.length} notes ?`}
+                </AlertDialogTitle>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel asChild>
+                  <Button variant="outline">Cancel</Button>
+                </AlertDialogCancel>
+                <AlertDialogAction asChild>
+                  <Button onClick={handleDelete}>Delete</Button>
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/note-list.tsx
+++ b/src/components/note-list.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Note } from '@/types';
 import { formatDistanceToNow } from 'date-fns';
-import { Plus, Trash2, Download } from 'lucide-react';
+import { Plus, Archive, Download } from 'lucide-react';
+import { ArchiveDialog } from '@/components/archive-dialog';
 import { downloadNote } from '@/lib/storage';
 
 interface NoteListProps {
@@ -12,19 +13,24 @@ interface NoteListProps {
   activeNoteId: string | null;
   onNoteSelect: (id: string) => void;
   onCreateNote: () => void;
-  onDeleteNote: (id: string) => void;
+  onArchiveNote: (id: string) => void;
+  onDeleteArchived: (ids: string[]) => void;
 }
 
-export function NoteList({ 
-  notes, 
-  activeNoteId, 
-  onNoteSelect, 
+export function NoteList({
+  notes,
+  activeNoteId,
+  onNoteSelect,
   onCreateNote,
-  onDeleteNote
+  onArchiveNote,
+  onDeleteArchived
 }: NoteListProps) {
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const activeNotes = notes.filter(n => !n.archived);
+  const archivedNotes = notes.filter(n => n.archived);
 
   useEffect(() => {
     if (editingNoteId && titleInputRef.current) {
@@ -44,10 +50,10 @@ export function NoteList({
     downloadNote(note);
   };
 
-  const handleDelete = (id: string) => (e: React.MouseEvent) => {
+  const handleArchive = (id: string) => (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    onDeleteNote(id);
+    onArchiveNote(id);
   };
 
   const startEditing = (note: Note) => (e: React.MouseEvent) => {
@@ -91,11 +97,12 @@ export function NoteList({
 
   return (
     <div className="h-full flex flex-col border-r">
-      <div className="p-4 border-b flex justify-between items-center">
+      <div className="p-4 border-b flex justify-between items-center gap-2">
         <h2 className="font-semibold text-sm">Notes</h2>
-        <Button 
-          variant="ghost" 
-          size="icon" 
+        <ArchiveDialog notes={archivedNotes} onDelete={onDeleteArchived} />
+        <Button
+          variant="ghost"
+          size="icon"
           onClick={(e) => {
             e.preventDefault();
             onCreateNote();
@@ -108,13 +115,13 @@ export function NoteList({
       
       <ScrollArea className="flex-1">
         <div className="px-2 py-2">
-          {notes.length === 0 ? (
+          {activeNotes.length === 0 ? (
             <p className="text-center text-muted-foreground text-sm p-4">
               No notes yet. Create one to get started.
             </p>
           ) : (
             <ul className="space-y-1">
-              {notes.map((note) => (
+              {activeNotes.map((note) => (
                 <li key={note.id} className="group">
                   <button
                     onClick={handleNoteSelect(note.id)}
@@ -160,10 +167,10 @@ export function NoteList({
                           variant="ghost"
                           size="icon"
                           className="h-8 w-8 text-destructive"
-                          onClick={handleDelete(note.id)}
-                          title="Delete note"
+                          onClick={handleArchive(note.id)}
+                          title="Archive note"
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Archive className="h-4 w-4" />
                         </Button>
                       </div>
                       <div className="text-xs text-muted-foreground truncate mt-1">

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -3,7 +3,7 @@ import { CommandAction } from '@/types';
 
 interface UseCommandsProps {
   createNote: () => void;
-  deleteNote: () => void;
+  archiveNote: () => void;
   saveNote: () => void;
   enterInsertMode: () => void;
   enterNormalMode: () => void;
@@ -13,7 +13,7 @@ interface UseCommandsProps {
 
 export function useCommands({
   createNote,
-  deleteNote,
+  archiveNote,
   saveNote,
   enterInsertMode,
   enterNormalMode,
@@ -30,11 +30,11 @@ export function useCommands({
       action: createNote,
     },
     {
-      id: 'delete-note',
-      name: 'Delete Note',
+      id: 'archive-note',
+      name: 'Archive Note',
       shortcut: 'dd',
-      description: 'Delete the current note',
-      action: deleteNote,
+      description: 'Archive the current note',
+      action: archiveNote,
     },
     {
       id: 'save-note',

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -29,8 +29,9 @@ export const createNote = (notes: Note[], title?: string): Note[] => {
     content: '',
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    archived: false,
   };
-  
+
   return [newNote, ...notes];
 };
 
@@ -49,6 +50,19 @@ export const updateNote = (notes: Note[], id: string, updates: Partial<Note>): N
 
 export const deleteNote = (notes: Note[], id: string): Note[] => {
   return notes.filter((note) => note.id !== id);
+};
+
+export const deleteNotes = (notes: Note[], ids: string[]): Note[] => {
+  const idSet = new Set(ids);
+  return notes.filter((note) => !idSet.has(note.id));
+};
+
+export const archiveNote = (notes: Note[], id: string): Note[] => {
+  return updateNote(notes, id, { archived: true });
+};
+
+export const unarchiveNote = (notes: Note[], id: string): Note[] => {
+  return updateNote(notes, id, { archived: false });
 };
 
 export const downloadNote = (note: Note) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,4 +4,5 @@ export interface Note {
   content: string;
   createdAt: string;
   updatedAt: string;
+  archived: boolean;
 }

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,4 +1,4 @@
-import { createNote, updateNote, deleteNote, saveNotes, loadNotes } from '../src/lib/storage';
+import { createNote, updateNote, deleteNote, deleteNotes, archiveNote, saveNotes, loadNotes } from '../src/lib/storage';
 import { Note } from '../src/types';
 
 describe('storage utilities', () => {
@@ -11,6 +11,7 @@ describe('storage utilities', () => {
     const result = createNote(notes, 'Test note');
     expect(result.length).toBe(1);
     expect(result[0].title).toBe('Test note');
+    expect(result[0].archived).toBe(false);
   });
 
   test('updateNote updates matching note', () => {
@@ -24,6 +25,21 @@ describe('storage utilities', () => {
     let notes: Note[] = createNote([], 'First');
     const id = notes[0].id;
     notes = deleteNote(notes, id);
+    expect(notes.length).toBe(0);
+  });
+
+  test('archiveNote marks note as archived', () => {
+    let notes: Note[] = createNote([], 'First');
+    const id = notes[0].id;
+    notes = archiveNote(notes, id);
+    expect(notes[0].archived).toBe(true);
+  });
+
+  test('deleteNotes removes all matching notes', () => {
+    let notes: Note[] = createNote([], 'First');
+    notes = createNote(notes, 'Second');
+    const ids = notes.map(n => n.id);
+    notes = deleteNotes(notes, ids);
     expect(notes.length).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
- add `archived` flag to `Note`
- provide storage helpers for archiving and deleting multiple notes
- track archived notes in `useNotes`
- add `ArchiveDialog` for listing archived notes and batch deletion with confirmation
- show archive actions in `NoteList`
- wire up archive features in `App`
- adjust command hook and tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841584c993c8331b6c99b78c95f5fcb