### PR TITLE
Implement responsive refactor and drop archive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,20 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { Editor } from '@/components/editor';
-import { NoteList } from '@/components/note-list';
 import { useNotes } from '@/hooks/useNotes';
+import { NoteManager } from '@/components/note-manager';
+import { Button } from '@/components/ui/button';
+import { Download, Plus, List } from 'lucide-react';
+import { downloadNote } from '@/lib/storage';
 
 function App() {
-  const { 
-    notes, 
-    activeNote, 
-    activeNoteId, 
-    setActiveNoteId, 
+  const {
+    notes,
+    activeNote,
+    activeNoteId,
+    setActiveNoteId,
     createNote,
     updateNote,
-    archiveNote,
-    unarchiveNote
+    deleteNotes
   } = useNotes();
 
   useEffect(() => {
@@ -34,29 +36,65 @@ function App() {
     }
   }, [activeNoteId, updateNote]);
 
+  const [title, setTitle] = useState('');
+
+  useEffect(() => {
+    setTitle(activeNote?.title || '');
+  }, [activeNote]);
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+    if (activeNoteId) {
+      updateNote(activeNoteId, { title: e.target.value });
+    }
+  };
+
+  const handleExport = () => {
+    if (activeNote) {
+      downloadNote(activeNote);
+    }
+  };
+
+  const Controls = () => (
+    <>
+      <Button size="icon" onClick={() => createNote()} title="New note">
+        <Plus className="w-4 h-4" />
+      </Button>
+      <Button size="icon" onClick={handleExport} title="Export">
+        <Download className="w-4 h-4" />
+      </Button>
+      <NoteManager
+        notes={notes}
+        onOpenNote={setActiveNoteId}
+        onDeleteNotes={deleteNotes}
+        trigger={
+          <Button size="icon" title="Manage notes">
+            <List className="w-4 h-4" />
+          </Button>
+        }
+      />
+    </>
+  );
+
   return (
     <div className="h-screen flex flex-col">
-      <div className="flex-1 flex overflow-hidden">
-        <div className="w-64 h-full">
-          <NoteList
-            notes={notes}
-            activeNoteId={activeNoteId}
-            onNoteSelect={setActiveNoteId}
-            onCreateNote={createNote}
-            onArchiveNote={archiveNote}
-            onUnarchiveNote={unarchiveNote}
-          />
+      <header className="p-2 border-b flex items-center justify-between">
+        <input
+          className="flex-1 bg-transparent outline-none text-lg font-medium"
+          value={title}
+          onChange={handleTitleChange}
+          placeholder="Untitled"
+        />
+        <div className="hidden sm:flex gap-2 ml-2">
+          <Controls />
         </div>
-        
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex-1 overflow-auto">
-            <Editor 
-              note={activeNote}
-              onContentChange={handleContentChange}
-            />
-          </div>
-        </div>
-      </div>
+      </header>
+      <main className="flex-1 overflow-auto">
+        <Editor note={activeNote} onContentChange={handleContentChange} />
+      </main>
+      <footer className="sm:hidden fixed bottom-0 inset-x-0 p-2 border-t bg-background flex justify-center gap-2">
+        <Controls />
+      </footer>
     </div>
   );
 }

--- a/src/components/note-manager.tsx
+++ b/src/components/note-manager.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { Note } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+import { downloadNote } from '@/lib/storage';
+import { Trash2, ExternalLink } from 'lucide-react';
+
+interface NoteManagerProps {
+  notes: Note[];
+  onOpenNote: (id: string) => void;
+  onDeleteNotes: (ids: string[]) => void;
+  trigger: React.ReactNode;
+}
+
+export function NoteManager({ notes, onOpenNote, onDeleteNotes, trigger }: NoteManagerProps) {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [confirm, setConfirm] = useState(false);
+
+  const toggle = (id: string) => {
+    setSelected(prev => prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]);
+  };
+
+  const handleBatchDelete = () => {
+    onDeleteNotes(selected);
+    setSelected([]);
+    setConfirm(false);
+  };
+
+  const handleBatchExport = () => {
+    selected.forEach(id => {
+      const note = notes.find(n => n.id === id);
+      if (note) downloadNote(note);
+    });
+    setSelected([]);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Manage Notes</DialogTitle>
+        </DialogHeader>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8" />
+              <TableHead>Title</TableHead>
+              <TableHead className="w-24 text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {notes.map(note => (
+              <TableRow key={note.id}>
+                <TableCell className="w-8">
+                  <Checkbox checked={selected.includes(note.id)} onCheckedChange={() => toggle(note.id)} />
+                </TableCell>
+                <TableCell className="truncate">
+                  {note.title || 'Untitled'} - {note.content.slice(0, 20)}
+                </TableCell>
+                <TableCell className="flex justify-end gap-2">
+                  <Button size="icon" variant="ghost" onClick={() => onOpenNote(note.id)} title="Open">
+                    <ExternalLink className="w-4 h-4" />
+                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button size="icon" variant="ghost" title="Delete">
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete note?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This action cannot be undone.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => onDeleteNotes([note.id])}>
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        {selected.length > 0 && (
+          <div className="flex justify-between mt-4">
+            <Button variant="destructive" onClick={() => setConfirm(true)}>
+              Delete Selected
+            </Button>
+            <Button onClick={handleBatchExport}>Export Selected</Button>
+          </div>
+        )}
+        <AlertDialog open={confirm} onOpenChange={setConfirm}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete {selected.length} notes?</AlertDialogTitle>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleBatchDelete}>Delete</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Note } from '@/types';
-import { loadNotes, saveNotes, createNote, updateNote, deleteNotes, archiveNote, unarchiveNote } from '@/lib/storage';
+import { loadNotes, saveNotes, createNote, updateNote, deleteNotes } from '@/lib/storage';
 
 export function useNotes() {
   const [notes, setNotes] = useState<Note[]>([]);
@@ -8,17 +8,18 @@ export function useNotes() {
   const [isLoading, setIsLoading] = useState(true);
 
   const activeNote = activeNoteId
-    ? notes.find(note => note.id === activeNoteId && !note.archived) || null
-    : notes.find(note => !note.archived) || null;
+    ? notes.find(note => note.id === activeNoteId) || null
+    : notes[0] || null;
 
   useEffect(() => {
     const loadedNotes = loadNotes();
     setNotes(loadedNotes);
 
-    const firstActive = loadedNotes.find(n => !n.archived);
-    if (firstActive && !activeNoteId) {
-      setActiveNoteId(firstActive.id);
-    } else if (loadedNotes.length === 0) {
+    if (loadedNotes.length > 0) {
+      if (!activeNoteId) {
+        setActiveNoteId(loadedNotes[0].id);
+      }
+    } else {
       const initialNotes = createNote([], 'Welcome to nanote');
       setNotes(initialNotes);
       setActiveNoteId(initialNotes[0].id);
@@ -45,33 +46,12 @@ export function useNotes() {
     setNotes((currentNotes) => updateNote(currentNotes, id, updates));
   };
 
-  const handleArchiveNote = (id: string) => {
-    setNotes((currentNotes) => {
-      const updated = archiveNote(currentNotes, id);
-      if (activeNoteId === id) {
-        const next = updated.find(n => n.id !== id && !n.archived);
-        if (next) {
-          setActiveNoteId(next.id);
-        } else {
-          const newList = createNote(updated, 'Untitled Note');
-          setActiveNoteId(newList[0].id);
-          return newList;
-        }
-      }
-      return updated;
-    });
-  };
-
-  const handleUnarchiveNote = (id: string) => {
-    setNotes((currentNotes) => unarchiveNote(currentNotes, id));
-  };
 
   const handleDeleteNotes = (ids: string[]) => {
-    setNotes((currentNotes) => {
+    setNotes(currentNotes => {
       const updated = deleteNotes(currentNotes, ids);
       if (ids.includes(activeNoteId || '')) {
-        const next = updated.find(n => !n.archived);
-        setActiveNoteId(next ? next.id : null);
+        setActiveNoteId(updated[0] ? updated[0].id : null);
       }
       return updated.length > 0 ? updated : createNote([], 'Untitled Note');
     });
@@ -84,8 +64,6 @@ export function useNotes() {
     setActiveNoteId,
     createNote: handleCreateNote,
     updateNote: handleUpdateNote,
-    archiveNote: handleArchiveNote,
-    unarchiveNote: handleUnarchiveNote,
     deleteNotes: handleDeleteNotes,
     isLoading,
   };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,7 +14,13 @@ export const saveNotes = (notes: Note[]): void => {
 export const loadNotes = (): Note[] => {
   try {
     const data = localStorage.getItem(STORAGE_KEY);
-    return data ? JSON.parse(data) : [];
+    if (!data) return [];
+    const parsed: any[] = JSON.parse(data);
+    // Migrate notes that may include an archived flag
+    return parsed.map(n => {
+      const { archived, ...rest } = n;
+      return rest as Note;
+    });
   } catch (error) {
     console.error('Failed to load notes from localStorage:', error);
     return [];
@@ -29,7 +35,6 @@ export const createNote = (notes: Note[], title?: string): Note[] => {
     content: '',
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    archived: false,
   };
 
   return [newNote, ...notes];
@@ -55,14 +60,6 @@ export const deleteNote = (notes: Note[], id: string): Note[] => {
 export const deleteNotes = (notes: Note[], ids: string[]): Note[] => {
   const idSet = new Set(ids);
   return notes.filter((note) => !idSet.has(note.id));
-};
-
-export const archiveNote = (notes: Note[], id: string): Note[] => {
-  return updateNote(notes, id, { archived: true });
-};
-
-export const unarchiveNote = (notes: Note[], id: string): Note[] => {
-  return updateNote(notes, id, { archived: false });
 };
 
 export const downloadNote = (note: Note) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,5 +4,4 @@ export interface Note {
   content: string;
   createdAt: string;
   updatedAt: string;
-  archived: boolean;
 }

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,4 +1,4 @@
-import { createNote, updateNote, deleteNote, deleteNotes, archiveNote, saveNotes, loadNotes } from '../src/lib/storage';
+import { createNote, updateNote, deleteNote, deleteNotes, saveNotes, loadNotes } from '../src/lib/storage';
 import { Note } from '../src/types';
 
 describe('storage utilities', () => {
@@ -11,7 +11,6 @@ describe('storage utilities', () => {
     const result = createNote(notes, 'Test note');
     expect(result.length).toBe(1);
     expect(result[0].title).toBe('Test note');
-    expect(result[0].archived).toBe(false);
   });
 
   test('updateNote updates matching note', () => {
@@ -28,12 +27,6 @@ describe('storage utilities', () => {
     expect(notes.length).toBe(0);
   });
 
-  test('archiveNote marks note as archived', () => {
-    let notes: Note[] = createNote([], 'First');
-    const id = notes[0].id;
-    notes = archiveNote(notes, id);
-    expect(notes[0].archived).toBe(true);
-  });
 
   test('deleteNotes removes all matching notes', () => {
     let notes: Note[] = createNote([], 'First');


### PR DESCRIPTION
## Summary
- refactor layout with header, editor and responsive control bar
- implement new `NoteManager` dialog for bulk note actions
- remove archive feature from data model and storage
- update hooks and tests accordingly

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68776cd8f9088331bd355546bacf6e2d