### PR TITLE
Fix note manager scroll and title focus

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -23,7 +23,7 @@ export function Editor({ note, onContentChange }: EditorProps) {
     if (textareaRef.current) {
       textareaRef.current.focus();
     }
-  }, [note]);
+  }, [note?.id]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newContent = e.target.value;

--- a/src/components/note-manager.tsx
+++ b/src/components/note-manager.tsx
@@ -28,6 +28,7 @@ import {
   TableRow,
   TableCell,
 } from '@/components/ui/table';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { downloadNote } from '@/lib/storage';
 import { Trash2, ExternalLink } from 'lucide-react';
 
@@ -68,7 +69,8 @@ export function NoteManager({ notes, onOpenNote, onDeleteNotes, trigger }: NoteM
         <DialogHeader>
           <DialogTitle>Manage Notes</DialogTitle>
         </DialogHeader>
-        <Table>
+        <ScrollArea className="h-[50vh]">
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
               <TableHead className="w-8" />
@@ -82,7 +84,7 @@ export function NoteManager({ notes, onOpenNote, onDeleteNotes, trigger }: NoteM
                 <TableCell className="w-8">
                   <Checkbox checked={selected.includes(note.id)} onCheckedChange={() => toggle(note.id)} />
                 </TableCell>
-                <TableCell className="truncate">
+                <TableCell className="max-w-0 truncate">
                   {note.title || 'Untitled'} - {note.content.slice(0, 20)}
                 </TableCell>
                 <TableCell className="flex justify-end gap-2">
@@ -115,6 +117,7 @@ export function NoteManager({ notes, onOpenNote, onDeleteNotes, trigger }: NoteM
             ))}
           </TableBody>
         </Table>
+        </ScrollArea>
         {selected.length > 0 && (
           <div className="flex justify-between mt-4">
             <Button variant="destructive" onClick={() => setConfirm(true)}>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -15,9 +15,10 @@ export const loadNotes = (): Note[] => {
   try {
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) return [];
-    const parsed: any[] = JSON.parse(data);
+    const parsed: Partial<Note & { archived?: boolean }>[] = JSON.parse(data);
     // Migrate notes that may include an archived flag
     return parsed.map(n => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { archived, ...rest } = n;
       return rest as Note;
     });


### PR DESCRIPTION
## Summary
- keep text editor focus when editing note title
- make Manage Notes dialog scrollable and truncate long titles
- clean up Note load migration types
- limit Manage Notes dialog scroll area to fixed height

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68777d80fbf08331acc648a9c6dc8b1f