### PR TITLE
Fix footer visibility on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
   );
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-[100dvh] flex flex-col">
       <header className="p-2 border-b flex items-center justify-between">
         <input
           className="flex-1 bg-transparent outline-none text-lg font-medium"

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 z-[100] flex max-h-[100dvh] w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- ensure the app uses `100dvh` so layout adapts when the keyboard is open
- use dynamic viewport units for toast container as well

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687793d03c8c8331bb7991ab3fd8a893