### PR TITLE
Fix sticky footer on mobile and memoize commands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,10 +89,10 @@ function App() {
           <Controls />
         </div>
       </header>
-      <main className="flex-1 overflow-auto">
+      <main className="flex-1 overflow-auto pb-16">
         <Editor note={activeNote} onContentChange={handleContentChange} />
       </main>
-      <footer className="sm:hidden fixed bottom-0 inset-x-0 p-2 border-t bg-background flex justify-center gap-2">
+      <footer className="sm:hidden sticky bottom-0 inset-x-0 p-2 border-t bg-background flex justify-center gap-2">
         <Controls />
       </footer>
     </div>

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { CommandAction } from '@/types';
 
 interface UseCommandsProps {
@@ -21,57 +21,68 @@ export function useCommands({
   toggleTheme,
 }: UseCommandsProps) {
   
-  const commands: CommandAction[] = [
-    {
-      id: 'new-note',
-      name: 'New Note',
-      shortcut: 'n',
-      description: 'Create a new note',
-      action: createNote,
-    },
-    {
-      id: 'archive-note',
-      name: 'Archive Note',
-      shortcut: 'dd',
-      description: 'Archive the current note',
-      action: archiveNote,
-    },
-    {
-      id: 'save-note',
-      name: 'Save Note',
-      shortcut: ':w',
-      description: 'Save the current note',
-      action: saveNote,
-    },
-    {
-      id: 'insert-mode',
-      name: 'Insert Mode',
-      shortcut: 'i',
-      description: 'Enter insert mode',
-      action: enterInsertMode,
-    },
-    {
-      id: 'normal-mode',
-      name: 'Normal Mode',
-      shortcut: 'Esc',
-      description: 'Enter normal mode',
-      action: enterNormalMode,
-    },
-    {
-      id: 'visual-mode',
-      name: 'Visual Mode',
-      shortcut: 'v',
-      description: 'Enter visual mode',
-      action: enterVisualMode,
-    },
-    {
-      id: 'toggle-theme',
-      name: 'Toggle Theme',
-      shortcut: ':theme',
-      description: 'Toggle between light and dark theme',
-      action: toggleTheme,
-    },
-  ];
+  const commands: CommandAction[] = useMemo(
+    () => [
+      {
+        id: 'new-note',
+        name: 'New Note',
+        shortcut: 'n',
+        description: 'Create a new note',
+        action: createNote,
+      },
+      {
+        id: 'archive-note',
+        name: 'Archive Note',
+        shortcut: 'dd',
+        description: 'Archive the current note',
+        action: archiveNote,
+      },
+      {
+        id: 'save-note',
+        name: 'Save Note',
+        shortcut: ':w',
+        description: 'Save the current note',
+        action: saveNote,
+      },
+      {
+        id: 'insert-mode',
+        name: 'Insert Mode',
+        shortcut: 'i',
+        description: 'Enter insert mode',
+        action: enterInsertMode,
+      },
+      {
+        id: 'normal-mode',
+        name: 'Normal Mode',
+        shortcut: 'Esc',
+        description: 'Enter normal mode',
+        action: enterNormalMode,
+      },
+      {
+        id: 'visual-mode',
+        name: 'Visual Mode',
+        shortcut: 'v',
+        description: 'Enter visual mode',
+        action: enterVisualMode,
+      },
+      {
+        id: 'toggle-theme',
+        name: 'Toggle Theme',
+        shortcut: ':theme',
+        description: 'Toggle between light and dark theme',
+        action: toggleTheme,
+      },
+    ],
+    [
+      createNote,
+      archiveNote,
+      saveNote,
+      enterInsertMode,
+      enterNormalMode,
+      enterVisualMode,
+      toggleTheme,
+    ]
+  );
 
   const handleShortcut = useCallback(
     (key: string) => {


### PR DESCRIPTION
## Summary
- keep mobile footer sticky instead of fixed
- pad main content so editor doesn't hide behind footer
- memoize commands to keep stable dependencies

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877a08aa51083319a36ed569f7116f2