### PR TITLE
Fix mobile header layout and scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,24 +77,21 @@ function App() {
   );
 
   return (
-    <div className="h-[100dvh] flex flex-col">
-      <header className="p-2 border-b flex items-center justify-between">
+    <div className="h-full flex flex-col">
+      <header className="p-2 border-b flex items-center gap-2">
         <input
-          className="flex-1 bg-transparent outline-none text-lg font-medium"
+          className="flex-1 min-w-0 bg-transparent outline-none text-lg font-medium"
           value={title}
           onChange={handleTitleChange}
           placeholder="Untitled"
         />
-        <div className="hidden sm:flex gap-2 ml-2">
+        <div className="flex gap-2 flex-shrink-0">
           <Controls />
         </div>
       </header>
-      <main className="flex-1 overflow-auto pb-16">
+      <main className="flex-1 overflow-hidden">
         <Editor note={activeNote} onContentChange={handleContentChange} />
       </main>
-      <footer className="sm:hidden sticky bottom-0 inset-x-0 p-2 border-t bg-background flex justify-center gap-2">
-        <Controls />
-      </footer>
     </div>
   );
 }

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -32,7 +32,7 @@ export function Editor({ note, onContentChange }: EditorProps) {
   };
 
   return (
-    <div className="relative h-full flex flex-col">
+    <div className="relative h-full flex flex-col overflow-auto">
       <textarea
         ref={textareaRef}
         value={content}

--- a/src/index.css
+++ b/src/index.css
@@ -59,8 +59,13 @@
   * {
     @apply border-border;
   }
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-hidden m-0;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }


### PR DESCRIPTION
## Summary
- keep controls in the header for all screen sizes
- remove footer controls
- limit overflow to the editor only
- ensure html and body fill the viewport without page scrolling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877bb994de08331b5702497c784e171